### PR TITLE
Fix for encoding bug during installation on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ if sys.version_info <= (3, 0):
           "(bleeding edge preferred)", file=sys.stderr)
     sys.exit(1)
 
-with open('README.rst') as f:
+with open('README.rst', encoding='utf8') as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
I had an issue installing jamo via pip on Windows:

```
Collecting jamo
  Downloading jamo-0.4.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\michael\AppData\Local\Temp\pip-build-_f6l863u\jamo\setup.py", line 11, in <module>
        long_description = f.read()
    UnicodeDecodeError: 'cp932' codec can't decode byte 0x94 in position 703: illegal multibyte sequence

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in C:\Users\michael\AppData\Local\Temp\pip-build-_f6l863u\jamo\
```

The source of the issue is that the open statement uses the system default encoding (which might not be utf8).  I've fixed the setup.py so that it no longer causes issues and installs properly.