### PR TITLE
Avoid printing to stderr on each exception

### DIFF
--- a/jamo/jamo.py
+++ b/jamo/jamo.py
@@ -47,8 +47,6 @@ class InvalidJamoError(Exception):
     def __init__(self, message, jamo):
         super(InvalidJamoError, self).__init__(message)
         self.jamo = hex(ord(jamo))
-        print("Could not parse jamo: U+{code}".format(code=self.jamo[2:]),
-              file=stderr)
 
 
 def _hangul_char_to_jamo(syllable):


### PR DESCRIPTION
I am using this library in a project, and that fact that it prints to stderr every time an `InvalidJamoError` is created is creating a lot of noise in the logs. I think it would be much better practice to simply allow the error to be handled as desired (whether that includes printing or not) inside of a `try:`/`except:` block.